### PR TITLE
Avoiding regex problems with newest version of require-all

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function() {
     function bootstrap(path) {
         requireAll({
             dirname:  path,
-            filter:  /^index.js$/,
+            filter:  /^(index.js)$/,
             resolve: function(component) {
                 api.include(component)
             }


### PR DESCRIPTION
require-all does not play well with non-capturing groups regex in their latest version, which makes systemic not to work with it.

I've created this PR for require-all: https://github.com/felixge/node-require-all/pull/43

Regardless of whether it's accepted or not, this would fix the issue.