### PR TITLE
fix: type should match code - `export default Systemic` is not correct, switch to `export = Systemic`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -192,4 +192,4 @@ export type Systemic<T extends Record<string, unknown>> = {
  */
 declare function Systemic<TMaster extends Record<string, unknown> = {}>(options?: { name?: string }): Systemic<TMaster>;
 
-export default Systemic;
+export = Systemic;


### PR DESCRIPTION
Types are not correct, they are not aligned with the code.
Similar to https://github.com/onebeyond/systemic-service-runner/pull/13

## Related Issue
Didn't open an issue, should I do it?

## Motivation and Context
This is an issue users encounter if they try to consume this module from an ESM service.

`export default Systemic` should be used if in the js file we were doing `export default Systemic;` -> the package is exported as a ES module.
When exporting a CJS module instead (like we're doing here with `module.exports = ...`) the type definition should be `export = Systemic;`

Typescript is probably clever enough to not raise any error when consuming this in a CJS service, but in an ESM environment it's raising an error, see screenshot of linked issue, it's the same

## How Has This Been Tested?
This is a change only in the types, I've tried it changing the type definition directly in the node_modules both in a ESM service and in a CJS service

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
