### PR TITLE
Release: 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "systemic",
-  "version": "4.1.2",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systemic",
-  "version": "4.1.2",
+  "version": "5.0.0",
   "description": "A minimal dependency injection library for node",
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION
## Braking changes

- The project now reflects that is using a MIT licence (https://github.com/onebeyond/systemic/pull/62)

## What's Changed
* Docs: Update license by @UlisesGascon in https://github.com/onebeyond/systemic/pull/62
* Improve readme badges by @inigomarquinez in https://github.com/onebeyond/systemic/pull/65
* ci: add code climate test report gh action by @inigomarquinez in https://github.com/onebeyond/systemic/pull/64
* docs: add inigomarquinez as a contributor for doc, maintenance, and review by @allcontributors[bot] in https://github.com/onebeyond/systemic/pull/66
* docs: add all-contributors badge by @inigomarquinez in https://github.com/onebeyond/systemic/pull/67
* Update README.md by @inigomarquinez in https://github.com/onebeyond/systemic/pull/68
* fix: type should match code - `export default Systemic` is not correct, switch to `export = Systemic` by @albertodeago in https://github.com/onebeyond/systemic/pull/69
* ci: add support for recent Node versions by @UlisesGascon in https://github.com/onebeyond/systemic/pull/70
* fix: correct typos in debug message and test description by @Ayoub-Mabrouk in https://github.com/onebeyond/systemic/pull/71
* test: add validation tests for null and undefined components by @Ayoub-Mabrouk in https://github.com/onebeyond/systemic/pull/73
* Bump json5 from 1.0.1 to 1.0.2 by @dependabot[bot] in https://github.com/onebeyond/systemic/pull/61

## New Contributors
* @allcontributors[bot] made their first contribution in https://github.com/onebeyond/systemic/pull/66
* @albertodeago made their first contribution in https://github.com/onebeyond/systemic/pull/69
* @Ayoub-Mabrouk made their first contribution in https://github.com/onebeyond/systemic/pull/71

**Full Changelog**: https://github.com/onebeyond/systemic/compare/v4.1.2...vx